### PR TITLE
Update core - remove webshell/shellinabox, add extra screenshots, tweak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,46 @@ Expected result: success or failure based on whether the pages required for the 
 
 Expects Selenium Webdriver to be listening somewhere accessible (default is `localhost:4444`, can be overridden by setting `TKL_WEBDRIVER_URL`).
 
-An easy way to get Selenium up and running is:
-
-```
-docker run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-chrome:4.7.2-20221219
-```
-
 To see what is happening in real time and interact with the browser manually, use noVNC at `localhost:7900` (password `secret`).
 
 To run appliances in Docker alongside Selenium for quick setup, please refer to the repo for [tkldev-docker](https://github.com/turnkeylinux/tkldev-docker).
 
 ## Tips and tricks
 
-Using the `core` testing scenario on any appliance will test and take screenshots of Shellinabox and Webmin.
+Using the `core` testing scenario on any appliance will test and take screenshots of Webmin.
+
+## Setup resources
+
+Install tools (to install on TKLDev/Debian)
+
+Rust: https://www.rust-lang.org/tools/install
+
+Docker: https://docs.docker.com/engine/install/debian/
+
+Selenium Webdriver:
+
+```
+docker run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-chrome:4.7.2-20221219
+```
+
+noVNC:
+
+```
+apt install novnc
+```
+Then from your local browser, browse to:
+
+```
+http://xxx.xxx.xxx.xxx:7900/vnc.html?host=yyy.yyy.yyy.yyy&port=7900
+```
+Where:
+    - `xxx.xxx.xxx.xxx` is the remote TKLDev IP
+    - `yyy.yyy.yyy.yyy` is the LAN IP of the Selenium container (setup as per above)
+    - above IPs can be the same (if they are running on the same host)
+    - `7900` is the default port and should not need adjustment
+
+E.g. I am running Selenium (via Docker) on my TKLDev (ip: 192.168.1.157), which also has noVNC installed. To connect:
+
+```
+http://192.168.1.157:7900/vnc.html?host=192.168.1.157&port=7900
+```

--- a/src/apps/core/mod.rs
+++ b/src/apps/core/mod.rs
@@ -19,10 +19,20 @@ pub async fn exec(st: State) -> WebDriverResult<()> {
             st.wd
                 .screenshot(&st.ssp.join("screenshot-webmin-login.png"))
                 .await?;
-            // webmin dashboard
+            // webmin landing page (tklbam)
             let submit = st.wd.find(By::Css("button[type='submit']")).await?;
             submit.click().await?;
             (st.wd.query(By::Id("headln2c")).first().await?)
+                .wait_until()
+                .displayed()
+                .await?;
+            st.wd
+                .screenshot(&st.ssp.join("screenshot-webmin-landing-tklbam.png"))
+                .await?;
+            // webmin dashboard
+            let submit = st.wd.find(By::Css("label[for='open_dashboard']")).await?;
+            submit.click().await?;
+            (st.wd.query(By::Css("g[class='ct-labels']")).first().await?)
                 .wait_until()
                 .displayed()
                 .await?;

--- a/src/apps/core/mod.rs
+++ b/src/apps/core/mod.rs
@@ -6,17 +6,6 @@ pub async fn exec(st: State) -> WebDriverResult<()> {
     match &st.act {
         Action::Test => {
             let mut u = st.url.clone();
-            // shellinabox
-            u.set_port(Some(12320))
-                .map_err(|_| ParseError::InvalidPort)?; // FIXME?
-            st.wd.goto(u.as_str()).await?;
-            (st.wd.query(By::Id("console")).first().await?)
-                .wait_until()
-                .displayed()
-                .await?;
-            st.wd
-                .screenshot(&st.ssp.join("screenshot-siab.png"))
-                .await?;
             // webmin login
             u.set_port(Some(12321))
                 .map_err(|_| ParseError::InvalidPort)?; // FIXME?

--- a/src/apps/core/mod.rs
+++ b/src/apps/core/mod.rs
@@ -39,6 +39,20 @@ pub async fn exec(st: State) -> WebDriverResult<()> {
             st.wd
                 .screenshot(&st.ssp.join("screenshot-webmin-dashboard.png"))
                 .await?;
+            // webmin terminal
+            let submit = st.wd.find(By::Css("li[aria-label='Command shell']")).await?;
+            submit.click().await?;
+            (st.wd.query(By::Css("div[class='-shell-port- opened']")).first().await?)
+                .wait_until()
+                .displayed()
+                .await?;
+            (st.wd.find(By::Css("input[type='text']")).await?)
+                .send_keys("apt-get update\n")
+                .await?;
+            st.sleep(3000).await; // wait for some output
+            st.wd
+                .screenshot(&st.ssp.join("screenshot-webmin-terminal.png"))
+                .await?;
             Ok(())
         }
         Action::Install => {


### PR DESCRIPTION
Now that Webmin has a proper interactive shell, we've dropped Webshell for v18.0, so it's no longer required.

<s>I did start having a play trying to get clicksnap to take a screenshot of both the actual dashboard (with the graphs and stuff - it currently takes a screenshot of the TKLBAM page) and I also thought it would be cool to take a screenshot of the terminal in action too, but I really struggled to work out how to make it work!?</s>

Ok, I have now added a screenshot of the Webmin Dashboard. I'll add one for the terminal too.