### PR TITLE
Remove unused imports

### DIFF
--- a/src/apps/phplist/mod.rs
+++ b/src/apps/phplist/mod.rs
@@ -1,6 +1,4 @@
-use super::{App, State, Step};
-use futures::FutureExt;
-use thirtyfour::prelude::*;
+use super::{App};
 
 pub const APP: App = App {
     test: &[

--- a/src/apps/postgresql/mod.rs
+++ b/src/apps/postgresql/mod.rs
@@ -1,6 +1,6 @@
-use super::{App, State, Step};
-use futures::FutureExt;
-use thirtyfour::prelude::*;
+use super::{App};
+
+
 
 pub const APP: App = App {
     test: &[

--- a/src/apps/postgresql/mod.rs
+++ b/src/apps/postgresql/mod.rs
@@ -1,7 +1,5 @@
 use super::{App};
 
-
-
 pub const APP: App = App {
     test: &[
     ],


### PR DESCRIPTION
Just removing unused imports - as recommended by rust (when running `cargo build`).