### PR TITLE
Some tweaks

### DIFF
--- a/src/apps/generic/webmin.rs
+++ b/src/apps/generic/webmin.rs
@@ -49,7 +49,7 @@ pub const STEPS: Steps = &[
         },
         ..Step::default()
     },
-    Step {
+    /*Step {
         name: "webmin-terminal",
         f: |st: &State| {
             async {
@@ -68,5 +68,5 @@ pub const STEPS: Steps = &[
             .boxed()
         },
         ..Step::default()
-    },
+    },*/
 ];

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -260,7 +260,7 @@ impl Runners {
         h.insert("etherpad", &etherpad::APP);
         h.insert("ezplatform", &ezplatform::APP);
         h.insert("fileserver", &fileserver::APP);
-        h.insert("foswiki", &foswiki::APP)
+        h.insert("foswiki", &foswiki::APP);
         h.insert("gallery", &gallery::APP);
         h.insert("gitea", &gitea::APP);
         h.insert("gitlab", &gitlab::APP);


### PR DESCRIPTION
Fix a minor typo and comment out `webmin-terminal` screenshot for now because the `webmin-shell' pacakge has been replaced by `webmin-xterm` - see https://github.com/turnkeylinux/common/pull/296

It'd be good to implement a screenshot of something similar at some point, but we'll worry about that later...