### PR TITLE
Add list command

### DIFF
--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -342,6 +342,12 @@ impl Runners {
         Self(h)
     }
 
+    pub fn list(&self) {
+        for (app, _) in &self.0 {
+            println!("{}", app);
+        }
+    }
+
     async fn try_run(&self, st: &State) -> Result<()> {
         let app = self
             .0

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,17 @@ async fn main() -> color_eyre::Result<()> {
     // parse args
     let args: Vec<String> = env::args().collect();
 
-    if args.len() != 4 {
+    if args.len() < 2 {
+        return Err(color_eyre::Report::msg(
+            "usage: tkl-webtest <action: test|install> <appliance name> <root URL>
+usage: tkl-webtest list",
+        ));
+    }
+
+    if args[1] == "list" {
+        Runners::new().list();
+        return Ok(());
+    } else if args.len() != 4 {
         return Err(color_eyre::Report::msg(
             "usage: tkl-webtest <action: test|install> <appliance name> <root URL>",
         ));


### PR DESCRIPTION
Adds cli command to list all appliances, for use in buildtasks

Run `clicksnap list` or `cargo run -- list` to list all supported appliances