### PR TITLE
Update canvas admin username

### DIFF
--- a/src/apps/canvas/mod.rs
+++ b/src/apps/canvas/mod.rs
@@ -3,7 +3,7 @@ use futures::FutureExt;
 use thirtyfour::prelude::*;
 
 // NOTE if the name is ever changed during install, change it here as well
-pub const ADMIN_ACCOUNT_NAME: &str = "TurnKey Canvas";
+pub const ADMIN_ACCOUNT_NAME: &str = "TurnKey super admin";
 pub const APP: App = App {
     test: &[
         Step {


### PR DESCRIPTION
The username of the Canvas "super" admin account has been updated v18.1 to make it's purpose obvious. This updates clicksnap to match the new name.