### PR TITLE
deffering canvas user name change

### DIFF
--- a/src/apps/canvas/mod.rs
+++ b/src/apps/canvas/mod.rs
@@ -3,7 +3,7 @@ use futures::FutureExt;
 use thirtyfour::prelude::*;
 
 // NOTE if the name is ever changed during install, change it here as well
-pub const ADMIN_ACCOUNT_NAME: &str = "TurnKey super admin";
+pub const ADMIN_ACCOUNT_NAME: &str = "TurnKey Canvas";
 pub const APP: App = App {
     test: &[
         Step {


### PR DESCRIPTION
Revert #94

The admin user name change will be deferred, hence reverting this change.